### PR TITLE
one sentence per line in the source file

### DIFF
--- a/01/03/en.md
+++ b/01/03/en.md
@@ -1,1 +1,4 @@
-Programming languages can be categorized in a number of ways: imperative, applicative, logic-based, problem-oriented, etc. But they all seem to be either an "agglutination of features" or a "crystallization of style." COBOL, PL/1, Ada, etc., belong to the first kind; LISP, APL— and Smalltalk—are the second kind. It is probably not an accident that the agglutinative languages all seem to have been instigated by committees, and the crystallization languages by a single person.
+Programming languages can be categorized in a number of ways: imperative, applicative, logic-based, problem-oriented, etc. 
+But they all seem to be either an "agglutination of features" or a "crystallization of style." 
+COBOL, PL/1, Ada, etc., belong to the first kind; LISP, APL— and Smalltalk—are the second kind. 
+It is probably not an accident that the agglutinative languages all seem to have been instigated by committees, and the crystallization languages by a single person.


### PR DESCRIPTION
The [paragraph and line break rule of markdown format](https://daringfireball.net/projects/markdown/syntax#p) allows us to put each sentence on a single line without line breaks in the final display.
So it might be a good idea to use "sentence" as our translation unit and put each sentence on a line.
(This does not apply to the markdown in the issue comments though, see the source of this comment itself.)

There are several advantages of this:

- Help us think at sentence level, which is a very important habit for understand and express complicated ideas.
- Easy to compare the original and translation texts at sentence level.
- Easy to see the [diff history](https://github.com/steam-maker/EHS-CN/blame/2e20e84293b6ae606cf0a2150d553a6f93b485d0/01/03/en.md) at sentence level.